### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -18,4 +18,4 @@ peek	KEYWORD2
 isEmpty	KEYWORD2
 isFull	KEYWORD2
 count	KEYWORD2
-setPrinter      KEYWORD2
+setPrinter	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords